### PR TITLE
Update to latest React Native specs

### DIFF
--- a/Hamburger.js
+++ b/Hamburger.js
@@ -204,7 +204,7 @@ export default class Hamburger extends Component {
         }
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
         if (nextProps.active !== this.state.active) {
             this._animate(nextProps.active);
         }


### PR DESCRIPTION
Renamed componentWillReceiveProps -> UNSAFE_componentWillReceiveProps due to react-native requirements: https://reactjs.org/docs/react-component.html